### PR TITLE
Installs and configures SMTP module

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,23 @@ For now, this is a work in progress.
 
 ## About the tooling
 
-This repository can be deployed on Pantheon via the Circle CI service, following the instructions in Pantheon's [Build Tools](https://pantheon.io/docs/guides/build-tools/) tutorial. It leverages the Terminus and Composer CLI tools, as well as unit tests from Behat and code linting on Circle CI.
+This repository can be deployed on Pantheon via the Circle CI service, following the instructions in Pantheon's [Build Tools](https://pantheon.io/docs/guides/build-tools/) tutorial. It leverages the Terminus (and Terminus Secrets Plugin) and Composer CLI tools, as well as unit tests from Behat and code linting on Circle CI.
 
 The badges at the top of this page will take you to the relevant resources and the running website.
+
+### Terminus Secrets
+
+This site includes the [SMTP](https://www.drupal.org/project/smtp) module, whose integration requires a username and password for sending email. Some of these settings should be managed using the [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin). The list of values that need to be defined are:
+
+- `smtp_from`
+- `smtp_fromname`
+- `smtp_host`
+- `smtp_password`
+- `smtp_port`
+- `smtp_protocol`
+- `smtp_username`
+
+Failure to define any of these values will result in the site not being able to send emails.
 
 ## Questions
 

--- a/composer.json
+++ b/composer.json
@@ -77,6 +77,7 @@
         "drupal/raven": "^2.7",
         "drupal/recaptcha": "^2.3",
         "drupal/simple_block": "^1.0@beta",
+        "drupal/smtp": "^1.0@beta",
         "drupal/superfish": "^1.3",
         "drupal/token": "^1.5",
         "drupal/video_embed_field": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "27ffdae236e04fe835635a69ab1a5ae4",
+    "content-hash": "249d3e00626145f2edd34c848ff88a80",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3367,6 +3367,74 @@
             "homepage": "https://www.drupal.org/project/simple_block",
             "support": {
                 "source": "https://git.drupalcode.org/project/simple_block"
+            }
+        },
+        {
+            "name": "drupal/smtp",
+            "version": "1.0.0-beta4",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/smtp.git",
+                "reference": "8.x-1.0-beta4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/smtp-8.x-1.0-beta4.zip",
+                "reference": "8.x-1.0-beta4",
+                "shasum": "80a4df4b2fd2d1b2dc653552d232ce98cb54bb9d"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-1.0-beta4",
+                    "datestamp": "1527598380",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "LukeLast",
+                    "homepage": "https://www.drupal.org/user/30151"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "josesanmartin",
+                    "homepage": "https://www.drupal.org/user/72012"
+                },
+                {
+                    "name": "oadaeh",
+                    "homepage": "https://www.drupal.org/user/4649"
+                },
+                {
+                    "name": "wundo",
+                    "homepage": "https://www.drupal.org/user/25523"
+                },
+                {
+                    "name": "yettyn",
+                    "homepage": "https://www.drupal.org/user/93281"
+                }
+            ],
+            "description": "Allow for site emails to be sent through an SMTP server of your choice.",
+            "homepage": "https://www.drupal.org/project/smtp",
+            "support": {
+                "source": "https://git.drupalcode.org/project/smtp",
+                "issues": "https://www.drupal.org/project/issues/smtp"
             }
         },
         {
@@ -9413,6 +9481,7 @@
         "drupal/htmlpurifier": 5,
         "drupal/libraries": 15,
         "drupal/simple_block": 10,
+        "drupal/smtp": 10,
         "drupal/webform": 5
     },
     "prefer-stable": true,

--- a/config/core.extension.yml
+++ b/config/core.extension.yml
@@ -54,6 +54,7 @@ module:
   search: 0
   shortcut: 0
   simple_block: 0
+  smtp: 0
   superfish: 0
   system: 0
   taxonomy: 0

--- a/config/smtp.settings.yml
+++ b/config/smtp.settings.yml
@@ -1,0 +1,17 @@
+smtp_on: true
+smtp_host: smtp.example.org
+smtp_hostbackup: ''
+smtp_port: '25'
+smtp_protocol: ssl
+smtp_username: NoUsernamesInGit
+smtp_password: 'NoPasswordsInGit'
+smtp_from: NoEmail@example.org
+smtp_fromname: 'No Names In Git'
+smtp_client_hostname: ''
+smtp_client_helo: ''
+smtp_allowhtml: '0'
+smtp_test_address: ''
+smtp_debugging: true
+prev_mail_system: php_mail
+_core:
+  default_config_hash: WEa5Ex_IeAcm6Bm0hmQ4vU_nDwJDB8hW-vxT1qpGIbM

--- a/config/system.mail.yml
+++ b/config/system.mail.yml
@@ -1,5 +1,4 @@
 interface:
-  default: php_mail
-  webform: webform_php_mail
+  default: SMTPMailSystem
 _core:
   default_config_hash: rYgt7uhPafP2ngaN_ZUPFuyI4KdE0zU868zLNSlzKoE

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -1,6 +1,29 @@
 <?php
 
 /**
+ * Load configuration overrides.
+ */
+$secrets_file = $_SERVER['HOME'] . '/files/private/secrets.json';
+/*
+if ( ! file_exists( $secrets_file ) ) {
+  // die('No secrets file found at ' . $secrets_file );
+}
+*/
+$secrets = json_decode( file_get_contents( $secrets_file ), 1 );
+/*
+if ( false == $secrets ) {
+  // die( 'Error parsing secrets file' );
+}
+*/
+$config['smtp.settings']['smtp_from']     = $secrets['smtp_from'];
+$config['smtp.settings']['smtp_fromname'] = $secrets['smtp_fromname'];
+$config['smtp.settings']['smtp_host']     = $secrets['smtp_host'];
+$config['smtp.settings']['smtp_password'] = $secrets['smtp_password'];
+$config['smtp.settings']['smtp_port']     = $secrets['smtp_port'];
+$config['smtp.settings']['smtp_protocol'] = $secrets['smtp_protocol'];
+$config['smtp.settings']['smtp_username'] = $secrets['smtp_username'];
+
+/**
  * Load services definition file.
  */
 $settings['container_yamls'][] = __DIR__ . '/services.yml';


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This adds the SMTP module, along with relevant configuration, to allow the application to send emails via MIT's outgoing service.

Of note - this feature requires the account's password to be defined, via the Terminus Secrets plugin, in the `smtp_password` key on each Pantheon tier. Failure to do this will prevent that tier from being able to send emails.

#### Helpful background context (if appropriate)
Pantheon's environment does not have the ability to send emails - so we need to build it back using the contrib SMTP module.

#### How can a reviewer manually see the effects of these changes?
Try resetting your password, or sending a test message via the configuration screen at `/admin/config/system/smtp`

#### Todo:
- [x] Documentation

#### Requires new or updated plugins, themes, or libraries?
YES - the Terminus Secrets plugin is required

#### Requires change to deploy process?
YES - the `smtp_password` key must be defined via Terminus Secrets plugin

